### PR TITLE
bumping gke version 

### DIFF
--- a/sh/k8s_library.sh
+++ b/sh/k8s_library.sh
@@ -4,7 +4,7 @@
 export GCP_VERBOSITY='warning'
 export GCP_ZONE='us-central1-c'
 export GKE_CHANNEL='rapid'
-export GKE_VERSION='1.18.6-gke.4801'
+export GKE_VERSION='1.18.9-gke.1501'
 export GKE_NODES=3
 export GKE_MACHINE='n1-standard-2'
 export PROMETHEUS_NS='monitoring'


### PR DESCRIPTION
While running the github action associated with deploying the k8s cluster, we ran into:

```sh
ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version must be one of "RAPID" channel supported versions [1.18.9-gke.801, 1.18.9-gke.1501].
```

This error is resolved now by bumping up to a supported gke version.